### PR TITLE
minor formatting changes

### DIFF
--- a/002 - Issue Megalist (MAIN)/1340 TO 1359.txt
+++ b/002 - Issue Megalist (MAIN)/1340 TO 1359.txt
@@ -32,7 +32,7 @@ The Debate
 4. “Wait! Now I am just a humble ordinary taxpayer,” says @@RANDOMNAME@@, pointing to the oversized, multicoloured badge on his chest that reads [i]Ordinary Taxpayer and Proud of It[/i], “but am I the only one who has the common sense to ask: why do we need a royal division in the first place? I’m not paying for it. We’re taxed enough already! If outdated royals want protection, make them work and fund their posh lifestyles like everyone else. They’ve scrounged enough on the national teat. Let’s save a penny or two for Mr and Ms Taxpayer!”
 
 --------------------------------------------------------------
-[b][anchor=1342]#1342[/anchor]: Uni-ted We Roll, Uni-ted We Fall [Fine Television Programming, ed: Candlewhisper Archive][/b]
+[b][anchor=1342]#1342[/anchor]: Uni-ted We Roll, Uni-ted We Fall [Fine Television Programming; ed: Candlewhisper Archive][/b]
 
 The Issue
 Public unicycle sharing systems have been appearing all over @@NAME@@. Daily ridership has ballooned to several hundred thousand users across the nation, but the populace is divided about longer term practicality, safety and stability.
@@ -58,7 +58,7 @@ The Debate
 3. “Are you insane?” interjects Hillary Murdoch, CEO of budget airline EasyBlues. “Do you have any idea how much that would cost us? Do you want to be the one who forces ticket prices up? This all happened because the pilot who crashed the damn plane locked the cockpit when his co-pilot stepped out for a few minutes. Just enact laws that keep both pilot and co-pilot in the cockpit at all times. Cuff them to their seats for the duration of the flight; that’ll stop them wandering.”
 
 --------------------------------------------------------------
-[b][anchor=1344]#1344[/anchor]: Ups and Downs [Candlewhisper Archive, ed: Candlewhisper Archive][/b]
+[b][anchor=1344]#1344[/anchor]: Ups and Downs [Candlewhisper Archive; ed: Candlewhisper Archive][/b]
 
 The Issue
 Trampoline parks are springing up all over @@NAME@@, with legions of playful children of all ages leaping off raised platforms and bouncing off mats. Perhaps predictably, large numbers of injuries are occurring with a multitude of sprained ankles, a not insignificant number of broken limbs, and even a bizarre incident where two amorous braces-wearing teenagers became entangled and required urgent medical intervention.

--- a/002 - Issue Megalist (MAIN)/1360 TO 1379.txt
+++ b/002 - Issue Megalist (MAIN)/1360 TO 1379.txt
@@ -74,7 +74,7 @@ The Debate
 5. “A license fee to watch TV? Public funding? What are we, East Lebatuckese?” questions billionaire media mogul RuPaul Murmarina, the owner of @@ANIMAL@@ News. “Forcing people to pay an archaic institution for supposedly impartial news and educational content is nonsense. I say privatise the broadcaster and let the free market do what it does best: meet the needs of the people by telling them what to think.”
 
 --------------------------------------------------------------
-[b][anchor=1366]#1366[/anchor]: Parklife [Pythaga; ed Gnejs][/b]
+[b][anchor=1366]#1366[/anchor]: Parklife [Pythaga; ed: Gnejs][/b]
 
 The Issue
 Public parks all across @@NAME@@ are in shambles, with sports fields overgrown and playgrounds rusting themselves to pieces, all due to a lack of sufficient funding. While the upper-crust of @@DEMONYMADJECTIVE@@ society have taken to funding and operating their own parks on private property, large segments of urban populations have been left recreationally disenfranchised. A plethora of interested parties are demanding that you take a swing at the problem.
@@ -87,7 +87,7 @@ The Debate
 3. “But that alone is not enough!” shouts @@RANDOMNAME@@, your neighbourhood dustman and part-time socialist, while waving a ‘Parks for the Proletariat’ poster in your face. “Public space is scarce, and you cannot continue to allow the upper-class to eat from their gold-plated picnic tables in their gated gardens. Take the lands those posh parks inhabit, and make them free to enjoy for all the people. From the hands of the rich, to walking hand-in-hand. That is the proper parklife.”
 
 --------------------------------------------------------------
-[b][anchor=1367]#1367[/anchor]: Sweet, Sweet Marketing [Lelscrep, ed: Candlewhisper Archive][/b]
+[b][anchor=1367]#1367[/anchor]: Sweet, Sweet Marketing [Lelscrep; ed: Candlewhisper Archive][/b]
 
 The Issue
 Recent studies show childhood obesity is on the rise, and many believe this to be the fault of attention-grabbing packaging on sugary foods.
@@ -113,7 +113,7 @@ The Debate
 3. “This plan is too complicated,” says the laconic Minister of Gordian Knots, who arrived in an ox cart and is now snipping at the air with a pair of scissors. “But doing nothing is not an option. Let us ban cars from the city instead. Stops congestion. Keeps things simple.”
 
 --------------------------------------------------------------
-[b][anchor=1369]#1369[/anchor]: Negotiation Complication [Westinor, ed: Candlewhisper Archive][/b]
+[b][anchor=1369]#1369[/anchor]: Negotiation Complication [Westinor; ed: Candlewhisper Archive][/b]
 
 The Issue
 For the past few months, your administration has been working on a landmark trade deal with the historically hostile nation of Blackacre. On the eve of the agreement’s planned signing, Georgia Mormont — a high-ranking official from the Blackacrean government — has approached you with the intent to defect.


### PR DESCRIPTION
fixed inconsistent use of commas and semicolons to split "authors" and "editors" from 1320 onwards
fixed 1 instance of missing colon in "ed: <editor>" from 1320 onwards